### PR TITLE
fix: perf improvement for failure spikes at nodelist refresh and added retries to increase availability sacrificing latency

### DIFF
--- a/benches/nodelist_benchmark_integrated.rs
+++ b/benches/nodelist_benchmark_integrated.rs
@@ -1,23 +1,16 @@
-use arc_swap::ArcSwap;
 use criterion::{criterion_group, criterion_main, Criterion};
 use liberdus_proxy::{
-    archivers::{self, ArchiverUtil},
-    config::{self, Config},
-    crypto::{self, ShardusCrypto},
-    liberdus::{Consensor, Liberdus, SignedNodeListResp},
+    archivers::{ArchiverUtil},
+    config::{Config},
+    crypto::{ShardusCrypto},
+    liberdus::Liberdus,
 };
-use rand::prelude::*;
 use std::time::Duration;
 use std::{
-    cmp::Ordering,
-    collections::HashMap,
     fs,
-    sync::{
-        atomic::{AtomicBool, AtomicUsize},
-        Arc,
-    },
+    sync::Arc,
 };
-use tokio::{runtime::Runtime, sync::RwLock};
+use tokio::runtime::Runtime;
 
 fn benchmark_get_consensor(c: &mut Criterion) {
     let mut group = c.benchmark_group("Integrated Get Next Server");

--- a/benches/nodelist_benchmark_integrated.rs
+++ b/benches/nodelist_benchmark_integrated.rs
@@ -70,15 +70,12 @@ fn benchmark_get_consensor(c: &mut Criterion) {
     }
 
     group.bench_function("Reads", |b| {
-        b.to_async(&rt).iter(|| async {
-            lbd.get_next_appropriate_consensor().await 
-        });
+        b.to_async(&rt)
+            .iter(|| async { lbd.get_next_appropriate_consensor().await });
     });
 
     bg1.abort();
-
 }
 
 criterion_group!(benches, benchmark_get_consensor);
 criterion_main!(benches);
-

--- a/benches/nodelist_benchmark_integrated.rs
+++ b/benches/nodelist_benchmark_integrated.rs
@@ -1,15 +1,9 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use liberdus_proxy::{
-    archivers::{ArchiverUtil},
-    config::{Config},
-    crypto::{ShardusCrypto},
-    liberdus::Liberdus,
+    archivers::ArchiverUtil, config::Config, crypto::ShardusCrypto, liberdus::Liberdus,
 };
 use std::time::Duration;
-use std::{
-    fs,
-    sync::Arc,
-};
+use std::{fs, sync::Arc};
 use tokio::runtime::Runtime;
 
 fn benchmark_get_consensor(c: &mut Criterion) {

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -496,24 +496,20 @@ impl Liberdus {
         );
 
         // tcp handshakes shouldn't take more than a second
-        let mut server_stream = match timeout(
-            Duration::from_millis(1000_u64),
-            TcpStream::connect(ip_port),
-        )
-        .await
-        {
-            Ok(Ok(stream)) => stream,
-            Ok(Err(e)) => {
-                eprintln!("Error connecting to target server: {}", e);
-                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
-                return Err(Box::new(e));
-            }
-            Err(_) => {
-                eprintln!("Timeout connecting to target server.");
-                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
-                return Err("Timeout connecting to target server".into());
-            }
-        };
+        let mut server_stream =
+            match timeout(Duration::from_millis(1000_u64), TcpStream::connect(ip_port)).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(e)) => {
+                    eprintln!("Error connecting to target server: {}", e);
+                    self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                    return Err(Box::new(e));
+                }
+                Err(_) => {
+                    eprintln!("Timeout connecting to target server.");
+                    self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                    return Err("Timeout connecting to target server".into());
+                }
+            };
 
         // Forward the request and collect response
         let now = std::time::Instant::now();

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -497,7 +497,7 @@ impl Liberdus {
 
         // tcp handshakes shouldn't take more than a second
         let mut server_stream = match timeout(
-            Duration::from_millis(1000 as u64),
+            Duration::from_millis(1000_u64),
             TcpStream::connect(ip_port),
         )
         .await
@@ -519,7 +519,7 @@ impl Liberdus {
         let now = std::time::Instant::now();
         let mut response_data = vec![];
         match timeout(
-            Duration::from_millis(1000 as u64),
+            Duration::from_millis(1000_u64),
             server_stream.write_all(&request_buffer),
         )
         .await

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -491,7 +491,7 @@ impl Liberdus {
 
         // tcp handshakes shouldn't take more than a second
         let mut server_stream = match timeout(
-            Duration::from_millis(500 as u64),
+            Duration::from_millis(1000 as u64),
             TcpStream::connect(ip_port),
         )
         .await
@@ -1307,7 +1307,7 @@ where
         match liberdus.send(request_buffer.clone()).await {
             Ok(response) => break response,
             Err(e) => {
-                if retry < 3 { retry += 1; sleep(Duration::from_millis(1)).await; continue; }
+                if retry < 3 { retry += 1; sleep(Duration::from_millis(100)).await; continue; }
                 eprintln!("Error sending request through liberdus: {}", e);
                 let error_str = e.to_string();
                 println!("{}",error_str);

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -476,7 +476,7 @@ impl Liberdus {
     /// This method abstracts the consensor selection, connection, and request/response handling
     pub async fn send(&self, request_buffer: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
         // Get the next appropriate consensor
-        let (_, target_server) = match self.get_next_appropriate_consensor_with_retry(3).await {
+        let (_, target_server) = match self.get_next_appropriate_consensor_with_retry(2).await {
             Some(consensor) => consensor,
             None => {
                 return Err("No consensors available after 3 retries".into());
@@ -1307,7 +1307,7 @@ where
         match liberdus.send(request_buffer.clone()).await {
             Ok(response) => break response,
             Err(e) => {
-                if retry < 3 { retry += 1; sleep(Duration::from_millis(200)).await; continue; }
+                if retry < 2 { retry += 1; sleep(Duration::from_millis(500)).await; continue; }
                 eprintln!("Error sending request through liberdus: {}", e);
                 let error_str = e.to_string();
                 println!("{}",error_str);

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -1307,7 +1307,7 @@ where
         match liberdus.send(request_buffer.clone()).await {
             Ok(response) => break response,
             Err(e) => {
-                if retry < 3 { retry += 1; sleep(Duration::from_millis(100)).await; continue; }
+                if retry < 3 { retry += 1; sleep(Duration::from_millis(200)).await; continue; }
                 eprintln!("Error sending request through liberdus: {}", e);
                 let error_str = e.to_string();
                 println!("{}",error_str);
@@ -1320,8 +1320,6 @@ where
             }
         }
     };
-
-    println!("Successfully forwarded request to server.");
 
     http::set_http_header(&mut response_data, "Connection", "keep-alive");
     http::set_http_header(

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -413,6 +413,21 @@ impl Liberdus {
         }
     }
 
+    pub async fn get_next_appropriate_consensor_with_retry(&self, max_retry: u32) -> Option<(usize, Consensor)> {
+        let mut retry = 0;
+        loop {
+            if let Some(respond) = self.get_next_appropriate_consensor().await {
+                return Some(respond);
+            }
+
+            if retry > max_retry {
+                return None;
+            }
+
+            retry += 1;
+        };
+    }
+
     pub fn set_consensor_trip_ms(&self, node_id: String, trip_ms: u128) {
         // list already prepared on the first round robin,  no need to keep recording rtt for nodes
         if self
@@ -453,6 +468,98 @@ impl Liberdus {
                 .to_vec(),
             &pk,
         )
+    }
+
+    /// Sends a request buffer to an appropriate consensor and returns the response buffer
+    /// This method abstracts the consensor selection, connection, and request/response handling
+    pub async fn send(&self, request_buffer: Vec<u8>) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+        // Get the next appropriate consensor
+        let (_, target_server) = match self.get_next_appropriate_consensor_with_retry(3).await {
+            Some(consensor) => consensor,
+            None => {
+                return Err("No consensors available after 3 retries".into());
+            }
+        };
+
+        let ip_port = format!(
+            "{}:{}",
+            target_server.ip.clone(),
+            target_server.port.clone()
+        );
+
+        let mut server_stream = match timeout(
+            Duration::from_millis(self.config.max_http_timeout_ms as u64),
+            TcpStream::connect(ip_port),
+        )
+        .await
+        {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(e)) => {
+                eprintln!("Error connecting to target server: {}", e);
+                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                return Err(Box::new(e));
+            }
+            Err(_) => {
+                eprintln!("Timeout connecting to target server.");
+                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                return Err("Timeout connecting to target server".into());
+            }
+        };
+
+        // Forward the request and collect response
+        let now = std::time::Instant::now();
+        let mut response_data = vec![];
+        match timeout(
+            Duration::from_millis(self.config.max_http_timeout_ms as u64),
+            server_stream.write_all(&request_buffer),
+        )
+        .await
+        {
+            Ok(Ok(())) => match http::collect_http(&mut server_stream, &mut response_data).await {
+                Ok(()) => {
+                    let elapsed = now.elapsed();
+                    self.set_consensor_trip_ms(target_server.id, elapsed.as_millis());
+                    tokio::spawn(async move {
+                        let _ = server_stream.shutdown().await;
+                        drop(server_stream);
+                    });
+                }
+                Err(e) => {
+                    eprintln!("Error reading response from server: {}", e);
+                    self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                    tokio::spawn(async move {
+                        let _ = server_stream.shutdown().await;
+                        drop(server_stream);
+                    });
+                    return Err(Box::new(e));
+                }
+            },
+            Ok(Err(e)) => {
+                eprintln!("Error forwarding request to server: {}", e);
+                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                tokio::spawn(async move {
+                    let _ = server_stream.shutdown().await;
+                    drop(server_stream);
+                });
+                return Err(Box::new(e));
+            }
+            Err(_) => {
+                eprintln!("Timeout forwarding request to server.");
+                self.set_consensor_trip_ms(target_server.id, self.config.max_http_timeout_ms);
+                tokio::spawn(async move {
+                    let _ = server_stream.shutdown().await;
+                    drop(server_stream);
+                });
+                return Err("Timeout forwarding request to server".into());
+            }
+        }
+
+        if response_data.is_empty() {
+            eprintln!("Empty response from server.");
+            return Err("Empty response from server".into());
+        }
+
+        Ok(response_data)
     }
 
     pub async fn get_account_by_address(
@@ -1117,6 +1224,48 @@ mod tests {
             .load(std::sync::atomic::Ordering::Relaxed));
     }
 
+    #[tokio::test]
+    async fn test_send_method() {
+        let mut cfg = sample_config();
+        cfg.max_http_timeout_ms = 2_000;
+
+        let ok_body = "ok";
+        let (server_handle, port) = start_http_server(format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            ok_body.len(),
+            ok_body
+        ))
+        .await;
+
+        let liberdus = sample_liberdus();
+        let mut nodes = liberdus.active_nodelist.load_full().as_ref().clone();
+        nodes.push(Consensor {
+            foundationNode: Some(false),
+            id: "fast".into(),
+            ip: "127.0.0.1".into(),
+            port,
+            publicKey: String::new(),
+            rng_bias: Some(1.0),
+        });
+        liberdus.active_nodelist.store(Arc::new(nodes));
+        liberdus
+            .load_distribution_commulative_bias
+            .write()
+            .await
+            .push(1.0);
+        liberdus
+            .list_prepared
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        let request = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n".to_vec();
+        
+        let response = liberdus.send(request).await.expect("send should succeed");
+        let response_str = std::str::from_utf8(&response).unwrap();
+        assert!(response_str.contains("ok"));
+
+        server_handle.abort();
+    }
+
     #[test]
     fn old_receipt_route_variants() {
         assert_eq!(
@@ -1150,100 +1299,25 @@ pub async fn handle_request<S>(
 where
     S: AsyncWrite + AsyncRead + Unpin + Send,
 {
-    // Get the next appropriate consensor from liberdus
-    let (_, target_server) = match liberdus.get_next_appropriate_consensor().await {
-        Some(consensor) => consensor,
-        None => {
-            eprintln!("No consensors available.");
-            http::respond_with_internal_error(client_stream).await?;
-            return Err("No consensors available".into());
-        }
-    };
-
-    let ip_port = format!(
-        "{}:{}",
-        target_server.ip.clone(),
-        target_server.port.clone()
-    );
-
-    let mut server_stream = match timeout(
-        Duration::from_millis(config.max_http_timeout_ms as u64),
-        TcpStream::connect(ip_port),
-    )
-    .await
-    {
-        Ok(Ok(stream)) => stream,
-        Ok(Err(e)) => {
-            eprintln!("Error connecting to target server: {}", e);
-            http::respond_with_timeout(client_stream).await?;
-            return Err(Box::new(e));
-        }
-        Err(_) => {
-            eprintln!("Timeout connecting to target server.");
-            http::respond_with_timeout(client_stream).await?;
-            return Err("Timeout connecting to target server".into());
-        }
-    };
-
-    // Forward the client's request to the server
-    let now = std::time::Instant::now();
-    let mut response_data = vec![];
-    match timeout(
-        Duration::from_millis(config.max_http_timeout_ms as u64),
-        server_stream.write_all(&request_buffer),
-    )
-    .await
-    {
-        Ok(Ok(())) => match http::collect_http(&mut server_stream, &mut response_data).await {
-            Ok(()) => {
-                let elapsed = now.elapsed();
-                liberdus.set_consensor_trip_ms(target_server.id, elapsed.as_millis());
-                tokio::spawn(async move {
-                    server_stream.shutdown().await.unwrap();
-                    drop(server_stream);
-                });
-            }
+    let mut retry = 0;
+    let mut response_data = loop {
+        match liberdus.send(request_buffer.clone()).await {
+            Ok(response) => break response,
             Err(e) => {
-                eprintln!("Error reading response from server: {}", e);
-                http::respond_with_internal_error(client_stream).await?;
-                liberdus.set_consensor_trip_ms(target_server.id, config.max_http_timeout_ms);
-                tokio::spawn(async move {
-                    server_stream.shutdown().await.unwrap();
-                    drop(server_stream);
-                });
-                return Err(Box::new(e));
+                if retry < 3 { retry += 1; continue; }
+                eprintln!("Error sending request through liberdus: {}", e);
+                let error_str = e.to_string();
+                if error_str.contains("Timeout") || error_str.contains("timeout") || error_str.contains("Connection refused") {
+                    http::respond_with_timeout(client_stream).await?;
+                } else {
+                    http::respond_with_internal_error(client_stream).await?;
+                }
+                return Err(e);
             }
-        },
-        Ok(Err(e)) => {
-            eprintln!("Error forwarding request to server: {}", e);
-            http::respond_with_internal_error(client_stream).await?;
-            liberdus.set_consensor_trip_ms(target_server.id, config.max_http_timeout_ms);
-            tokio::spawn(async move {
-                server_stream.shutdown().await.unwrap();
-                drop(server_stream);
-            });
-            return Err(Box::new(e));
         }
-        Err(_) => {
-            eprintln!("Timeout forwarding request to server.");
-            http::respond_with_timeout(client_stream).await?;
-            liberdus.set_consensor_trip_ms(target_server.id, config.max_http_timeout_ms);
-            tokio::spawn(async move {
-                server_stream.shutdown().await.unwrap();
-                drop(server_stream);
-            });
-            return Err("Timeout forwarding request to server".into());
-        }
-    }
+    };
+
     println!("Successfully forwarded request to server.");
-
-    drop(request_buffer);
-
-    if response_data.is_empty() {
-        eprintln!("Empty response from server.");
-        http::respond_with_internal_error(client_stream).await?;
-        return Err("Empty response from server".into());
-    }
 
     http::set_http_header(&mut response_data, "Connection", "keep-alive");
     http::set_http_header(

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -487,8 +487,9 @@ impl Liberdus {
             target_server.port.clone()
         );
 
+        // tcp handshakes shouldn't take more than a second
         let mut server_stream = match timeout(
-            Duration::from_millis(self.config.max_http_timeout_ms as u64),
+            Duration::from_millis(500 as u64),
             TcpStream::connect(ip_port),
         )
         .await
@@ -510,7 +511,7 @@ impl Liberdus {
         let now = std::time::Instant::now();
         let mut response_data = vec![];
         match timeout(
-            Duration::from_millis(self.config.max_http_timeout_ms as u64),
+            Duration::from_millis(1000 as u64),
             server_stream.write_all(&request_buffer),
         )
         .await

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -4,6 +4,7 @@ use crate::{archivers, collector, config, http};
 use arc_swap::ArcSwap;
 use rand::prelude::*;
 use serde::{self, Deserialize, Serialize};
+use tokio::time::sleep;
 use std::{
     cmp::Ordering,
     collections::HashMap,
@@ -425,6 +426,7 @@ impl Liberdus {
             }
 
             retry += 1;
+            sleep(Duration::from_millis(1)).await;
         };
     }
 
@@ -1305,9 +1307,10 @@ where
         match liberdus.send(request_buffer.clone()).await {
             Ok(response) => break response,
             Err(e) => {
-                if retry < 3 { retry += 1; continue; }
+                if retry < 3 { retry += 1; sleep(Duration::from_millis(1)).await; continue; }
                 eprintln!("Error sending request through liberdus: {}", e);
                 let error_str = e.to_string();
+                println!("{}",error_str);
                 if error_str.contains("Timeout") || error_str.contains("timeout") || error_str.contains("Connection refused") {
                     http::respond_with_timeout(client_stream).await?;
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         });
 
-
         // schedule a background task that refresh archiver list
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(tokio::time::Duration::from_secs(

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -604,7 +604,6 @@ pub(crate) mod tests {
         assert!(rx.try_recv().is_err());
     }
 
-
     #[test]
     fn test_subscription_actions_from_str() {
         let sub = SubscriptionActions::from("subscribe");

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -385,7 +385,7 @@ pub(crate) mod tests {
     use crate::config;
     use crate::crypto::ShardusCrypto;
     use crate::liberdus;
-    use crate::ws;
+    
     use arc_swap::ArcSwap;
     use std::collections::HashMap;
     use std::sync::Arc;

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -385,7 +385,7 @@ pub(crate) mod tests {
     use crate::config;
     use crate::crypto::ShardusCrypto;
     use crate::liberdus;
-    
+
     use arc_swap::ArcSwap;
     use std::collections::HashMap;
     use std::sync::Arc;


### PR DESCRIPTION
Fixed HTTP proxy failures caused by stale reads during atomic node list swaps. Decoupled the archiver refresh from the node list refresh to mitigate burst performance penalties, as the archiver list changes infrequently. Added a retry mechanism to improve success rates at the expense of latency and throughput