### PR TITLE
Adds bridgeout coordinator gateway

### DIFF
--- a/src/archivers.rs
+++ b/src/archivers.rs
@@ -273,6 +273,7 @@ mod tests {
                 ip: String::new(),
                 port: 0,
             },
+            coordinator_url: None,
         }
     }
 

--- a/src/config.json
+++ b/src/config.json
@@ -36,5 +36,6 @@
     "notifier": {
         "ip": "127.0.0.1",
         "port": 4701
-    }
+    },
+    "coordinator_url": "http://127.0.0.1:8000"
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,11 @@ pub struct Config {
     pub local_source: LocalSource,
 
     pub notifier: NotifierConfig,
+
+    /// Base URL of the bridge coordinator (e.g. http://127.0.0.1:8000). Used to forward
+    /// POST /notify-bridgeout from the bridge UI so the coordinator can poll for BridgeOut events.
+    #[serde(default)]
+    pub coordinator_url: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, Clone)]

--- a/src/coordinator_gateway.rs
+++ b/src/coordinator_gateway.rs
@@ -1,0 +1,134 @@
+//! Forwards bridge UI notify-bridgeout requests to the coordinator.
+//!
+//! Flow: Bridge UI → Liberdus Proxy (this) → immediate 200 to UI; in background, proxy
+//! forwards to coordinator, awaits response, and logs the result.
+//!
+//! Coordinator API (see tss-signer/coordinator):
+//! - POST /notify-bridgeout
+//! - Request body: `{ "chainId": number }`
+//! - Response: `{ "Ok": "triggered" | "queued" | "cooldown" }` or 400 `{ "Err": "..." }`
+
+use crate::config::Config;
+use crate::http;
+use std::sync::Arc;
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+
+/// True if this is POST /notify-bridgeout (exact path, no query).
+pub fn is_notify_bridgeout_route(method: &str, route: &str) -> bool {
+    method.eq_ignore_ascii_case("POST")
+        && route
+            .split('?')
+            .next()
+            .map(|p| p == "/notify-bridgeout")
+            .unwrap_or(false)
+}
+
+pub async fn handle_request<S>(
+    request_buffer: Vec<u8>,
+    client_stream: &mut S,
+    config: Arc<Config>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    S: AsyncWrite + AsyncRead + Unpin + Send,
+{
+    let coordinator_url = match config.coordinator_url.as_deref() {
+        Some(u) if !u.is_empty() => u.to_string(),
+        _ => {
+            eprintln!("[notify-bridgeout] coordinator_url not configured");
+            respond_503(client_stream, "coordinator_url not configured").await?;
+            return Err("coordinator_url not configured".into());
+        }
+    };
+
+    let body = http::extract_body(&request_buffer);
+
+    // Validate request: Bridge UI sends JSON.stringify({ chainId }) — body must be {"chainId": number}
+    if body.is_empty() {
+        eprintln!("[notify-bridgeout] rejected: empty body");
+        respond_json(client_stream, 400, r#"{"Err":"Invalid or missing chainId"}"#).await?;
+        return Ok(());
+    }
+    let chain_id_valid = serde_json::from_slice::<serde_json::Value>(&body)
+        .ok()
+        .and_then(|v| v.get("chainId").and_then(|n| n.as_u64().or_else(|| n.as_i64().map(|i| i as u64))))
+        .is_some();
+    if !chain_id_valid {
+        eprintln!("[notify-bridgeout] rejected: invalid or missing chainId in body");
+        respond_json(client_stream, 400, r#"{"Err":"Invalid or missing chainId"}"#).await?;
+        return Ok(());
+    }
+
+    // Respond to Bridge UI immediately so it is not blocked
+    respond_json(client_stream, 200, r#"{"Ok":"accepted"}"#).await?;
+
+    // Forward to coordinator in background; await coordinator response and log result
+    tokio::spawn(async move {
+        let url = format!("{}/notify-bridgeout", coordinator_url.trim_end_matches('/'));
+        let client = reqwest::Client::new();
+        match client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .body(body)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(res) => {
+                let status = res.status();
+                let body = res.bytes().await.unwrap_or_default();
+                let body_str = String::from_utf8_lossy(&body);
+                if status.is_success() {
+                    println!("[notify-bridgeout] coordinator ok status={} body={}", status, body_str);
+                } else {
+                    eprintln!(
+                        "[notify-bridgeout] coordinator error status={} body={}",
+                        status, body_str
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("[notify-bridgeout] coordinator request failed: {} (url={})", e, url);
+            }
+        }
+    });
+
+    Ok(())
+}
+
+async fn respond_503<S>(client_stream: &mut S, message: &str) -> Result<(), std::io::Error>
+where
+    S: AsyncWrite + Unpin + Send,
+{
+    let body = format!(r#"{{"Err":"{}"}}"#, escape_json(message));
+    respond_json(client_stream, 503, &body).await
+}
+
+fn escape_json(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+async fn respond_json<S>(
+    client_stream: &mut S,
+    status_code: u16,
+    body: &str,
+) -> Result<(), std::io::Error>
+where
+    S: AsyncWrite + Unpin + Send,
+{
+    let status_line = match status_code {
+        200 => "200 OK",
+        400 => "400 Bad Request",
+        503 => "503 Service Unavailable",
+        500 => "500 Internal Server Error",
+        _ => "500 Internal Server Error",
+    };
+    let body_bytes = body.as_bytes();
+    let response = format!(
+        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n{}",
+        status_line,
+        body_bytes.len(),
+        body
+    );
+    client_stream.write_all(response.as_bytes()).await?;
+    client_stream.flush().await
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -15,7 +15,7 @@
 //! - `read_or_collect`: Reads and collects request or response data with header parsing.
 //! - `respond_with_internal_error`: Sends a 500 Internal Server Error response to the client.
 //! - `respond_with_timeout`: Sends a 504 Gateway Timeout response to the client.
-use crate::{collector, config, liberdus, notifier, shardus_monitor, subscription, Stats};
+use crate::{collector, config, coordinator_gateway, liberdus, notifier, shardus_monitor, subscription, Stats};
 use std::borrow::Cow;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -28,10 +28,14 @@ enum Application {
     Notifier,
     Monitor,
     Debug,
+    /// Bridge UI notify-bridgeout → proxy → coordinator
+    CoordinatorGateway,
 }
 
-fn get_application(route: &str) -> Application {
-    if shardus_monitor::proxy::is_monitor_route(route) {
+fn get_application(method: &str, route: &str) -> Application {
+    if coordinator_gateway::is_notify_bridgeout_route(method, route) {
+        Application::CoordinatorGateway
+    } else if shardus_monitor::proxy::is_monitor_route(route) {
         Application::Monitor
     } else if collector::is_collector_route(route) {
         Application::Collector
@@ -128,9 +132,17 @@ where
         .await
         {
             Ok(Ok(())) => {
-                let (_method, route) = get_route(&req_buf).unwrap();
+                let (method, route) = get_route(&req_buf).unwrap();
 
-                match get_application(route.as_str()) {
+                match get_application(&method, &route) {
+                    Application::CoordinatorGateway => {
+                        if let Err(e) =
+                            coordinator_gateway::handle_request(req_buf, &mut client_stream, config.clone()).await
+                        {
+                            eprintln!("Error handling notify-bridgeout: {}", e);
+                        }
+                        continue;
+                    }
                     Application::Monitor => {
                         if let Err(e) = shardus_monitor::proxy::handle_request(
                             req_buf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub struct Stats {
 pub mod archivers;
 pub mod collector;
 pub mod config;
+pub mod coordinator_gateway;
 pub mod crypto;
 pub mod http;
 pub mod liberdus;

--- a/src/liberdus.rs
+++ b/src/liberdus.rs
@@ -789,6 +789,7 @@ mod tests {
                 ip: String::new(),
                 port: 0,
             },
+            coordinator_url: None,
         }
     }
 

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -172,6 +172,7 @@ mod tests {
                 ip: "127.0.0.1".into(),
                 port,
             },
+            coordinator_url: None,
         }
     }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -431,6 +431,7 @@ pub(crate) mod tests {
                 ip: String::new(),
                 port: 0,
             },
+            coordinator_url: None,
         }
     }
 

--- a/tests/consistency_test.rs
+++ b/tests/consistency_test.rs
@@ -110,6 +110,7 @@ async fn test_nodelist_consistency_lockstep() {
             ip: String::new(),
             port: 0,
         },
+        coordinator_url: None,
     });
     config.max_http_timeout_ms = 500;
     config.nodelist_refresh_interval_sec = 1;

--- a/tests/coordinator_gateway_test.rs
+++ b/tests/coordinator_gateway_test.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use tokio::io::AsyncReadExt;
+
+use liberdus_proxy::config;
+use liberdus_proxy::coordinator_gateway;
+
+fn test_config(coordinator_url: Option<String>) -> config::Config {
+    config::Config {
+        http_port: 0,
+        crypto_seed: String::new(),
+        archiver_seed_path: String::new(),
+        nodelist_refresh_interval_sec: 1,
+        debug: true,
+        max_http_timeout_ms: 1_000,
+        tcp_keepalive_time_sec: 1,
+        standalone_network: config::StandaloneNetworkConfig {
+            replacement_ip: "127.0.0.1".into(),
+            enabled: false,
+        },
+        node_filtering: config::NodeFilteringConfig {
+            enabled: false,
+            remove_top_nodes: 0,
+            remove_bottom_nodes: 0,
+            min_nodes_for_filtering: 0,
+        },
+        tls: config::TLSConfig {
+            enabled: false,
+            cert_path: String::new(),
+            key_path: String::new(),
+        },
+        shardus_monitor: config::ShardusMonitorProxyConfig {
+            enabled: false,
+            upstream_ip: String::new(),
+            upstream_port: 0,
+            https: false,
+        },
+        local_source: config::LocalSource {
+            collector_api_ip: String::new(),
+            collector_api_port: 0,
+            collector_event_server_ip: String::new(),
+            collector_event_server_port: 0,
+        },
+        notifier: config::NotifierConfig {
+            ip: String::new(),
+            port: 0,
+        },
+        coordinator_url,
+    }
+}
+
+fn post_request_with_body(body: &str) -> Vec<u8> {
+    let mut buf = b"POST /notify-bridgeout HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: "
+        .to_vec();
+    buf.extend_from_slice(body.len().to_string().as_bytes());
+    buf.extend_from_slice(b"\r\n\r\n");
+    buf.extend_from_slice(body.as_bytes());
+    buf
+}
+
+async fn run_handle_request(request_buffer: Vec<u8>, config: Arc<config::Config>) -> Vec<u8> {
+    let (mut client, mut peer) = tokio::io::duplex(1024);
+    let config_clone = Arc::clone(&config);
+    let handle = tokio::spawn(async move {
+        let _ = coordinator_gateway::handle_request(request_buffer, &mut client, config_clone).await;
+    });
+    let mut output = vec![0u8; 512];
+    let n = peer.read(&mut output).await.unwrap();
+    handle.await.unwrap();
+    output[..n].to_vec()
+}
+
+#[test]
+fn test_is_notify_bridgeout_route() {
+    assert!(coordinator_gateway::is_notify_bridgeout_route("POST", "/notify-bridgeout"));
+    assert!(coordinator_gateway::is_notify_bridgeout_route("post", "/notify-bridgeout"));
+    assert!(coordinator_gateway::is_notify_bridgeout_route("POST", "/notify-bridgeout?x=1"));
+    assert!(!coordinator_gateway::is_notify_bridgeout_route("GET", "/notify-bridgeout"));
+    assert!(!coordinator_gateway::is_notify_bridgeout_route("POST", "/other"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_handle_request_valid_and_errors() {
+    let config_ok = Arc::new(test_config(Some("http://127.0.0.1:0".into())));
+    let config_no_url = Arc::new(test_config(None));
+
+    // Valid body → 200 accepted
+    let res = run_handle_request(post_request_with_body(r#"{"chainId":80002}"#), config_ok.clone()).await;
+    let text = String::from_utf8_lossy(&res);
+    assert!(text.starts_with("HTTP/1.1 200 OK") && text.contains(r#"{"Ok":"accepted"}"#), "{}", text);
+
+    // Invalid bodies → 400
+    for invalid_body in ["", "not json", r#"{"other":123}"#, r#"{"chainId":"80002"}"#] {
+        let res = run_handle_request(post_request_with_body(invalid_body), config_ok.clone()).await;
+        let text = String::from_utf8_lossy(&res);
+        assert!(text.starts_with("HTTP/1.1 400"), "body {:?} should get 400, got: {}", invalid_body, text);
+    }
+
+    // No coordinator_url → 503
+    let res = run_handle_request(post_request_with_body(r#"{"chainId":80002}"#), config_no_url).await;
+    let text = String::from_utf8_lossy(&res);
+    assert!(text.starts_with("HTTP/1.1 503") && text.contains("coordinator_url not configured"), "{}", text);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -46,6 +46,7 @@ fn test_config(port: u16) -> Arc<config::Config> {
             ip: String::new(),
             port: 0,
         },
+        coordinator_url: None,
     })
 }
 


### PR DESCRIPTION
Introduces a new `coordinator_gateway` module to facilitate forwarding of `/notify-bridgeout` requests from the Bridge UI to an external coordinator service. This feature improves the bridge's operational flow by allowing the proxy to act as an intermediary for these notifications.

Key changes include:
- A new `coordinator_url` configuration option is added to specify the bridge coordinator's base URL. This URL is used by the gateway to forward `POST /notify-bridgeout` requests.
- The proxy now processes `/notify-bridgeout` requests by immediately responding to the Bridge UI with a 200 OK status to prevent blocking.
- The request, after validation for a `chainId` in its body, is then asynchronously forwarded to the configured coordinator URL.
- Comprehensive unit tests are included for the new `coordinator_gateway` to ensure its correct functionality and error handling.