### PR TITLE
Fix DevSecOps pipeline issues

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -34,11 +37,28 @@ jobs:
     - name: Redirect
       run: echo '<!DOCTYPE HTML><html lang="en-US"><head><meta charset="UTF-8"><meta http-equiv="refresh" content="0; url=https://liberdus.com/liberdus-proxy/liberdus_proxy"><script type="text/javascript">window.location.href = "https://liberdus.com/liberdus-proxy/liberdus_proxy"</script><title>Page Redirection</title></head><body>If you are not redirected automatically, follow this <a href="https://liberdus.com/liberdus-proxy/liberdus_proxy">link to example</a>.</body></html>' > ./target/doc/index.html
 
+    - name: Upload docs
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs
+        path: target/doc/
+
+  deploy-docs:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Download docs
+      uses: actions/download-artifact@v4
+      with:
+        name: docs
+        path: target/doc/
 
     - name: Deploy to gh-pages
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/doc/
-

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -382,7 +382,7 @@ where
                     return Err(Box::new(e));
                 }
             }
-        },
+        }
         Ok(Err(e)) => {
             eprintln!("Error forwarding request to collector api server: {}", e);
             http::respond_with_internal_error(client_stream).await?;

--- a/src/http.rs
+++ b/src/http.rs
@@ -31,7 +31,7 @@ fn get_timestamp() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    
+
     // Format as human-readable timestamp (you can adjust format as needed)
     format!("{}", now)
 }
@@ -142,8 +142,12 @@ pub async fn handle_stream<StreamLike>(
 where
     StreamLike: AsyncWrite + AsyncRead + Unpin + Send,
 {
-    println!("[{}] [HTTP_CONNECT] IP: {} | New connection established", get_timestamp(), client_addr);
-    
+    println!(
+        "[{}] [HTTP_CONNECT] IP: {} | New connection established",
+        get_timestamp(),
+        client_addr
+    );
+
     loop {
         let mut req_buf = Vec::new();
         match timeout(
@@ -158,35 +162,58 @@ where
                     // Client closed connection cleanly
                     break;
                 }
-                
+
                 // Log that we received data
-                println!("[{}] [HTTP_DATA] IP: {} | Received {} bytes", get_timestamp(), client_addr, req_buf.len());
-                
+                println!(
+                    "[{}] [HTTP_DATA] IP: {} | Received {} bytes",
+                    get_timestamp(),
+                    client_addr,
+                    req_buf.len()
+                );
+
                 // Log warning for unusually large requests
                 if req_buf.len() > 100_000 {
-                    eprintln!("[{}] [HTTP_WARNING] IP: {} | Large request received: {} bytes", get_timestamp(), client_addr, req_buf.len());
+                    eprintln!(
+                        "[{}] [HTTP_WARNING] IP: {} | Large request received: {} bytes",
+                        get_timestamp(),
+                        client_addr,
+                        req_buf.len()
+                    );
                 }
-                
+
                 let method_route = match get_route(&req_buf) {
                     Some(route_info) => route_info,
                     None => {
-                        eprintln!("[{}] [HTTP_ERROR] IP: {} | Failed to extract route from request", get_timestamp(), client_addr);
+                        eprintln!(
+                            "[{}] [HTTP_ERROR] IP: {} | Failed to extract route from request",
+                            get_timestamp(),
+                            client_addr
+                        );
                         // Log the first 200 bytes of the request for debugging
                         if let Ok(req_str) = std::str::from_utf8(&req_buf) {
-                            let preview = if req_str.len() > 200 { &req_str[..200] } else { req_str };
-                            eprintln!("[{}] [HTTP_DEBUG] IP: {} | Request preview: {:?}", get_timestamp(), client_addr, preview);
+                            let preview = if req_str.len() > 200 {
+                                &req_str[..200]
+                            } else {
+                                req_str
+                            };
+                            eprintln!(
+                                "[{}] [HTTP_DEBUG] IP: {} | Request preview: {:?}",
+                                get_timestamp(),
+                                client_addr,
+                                preview
+                            );
                         }
                         break;
                     }
                 };
-                
+
                 let (method, route) = method_route;
-                
+
                 // Extract client information for logging
                 let user_agent = extract_user_agent(&req_buf);
                 let client_ip = extract_client_ip(&req_buf, &client_addr);
                 let (platform, app_version, device_id) = extract_client_info(&req_buf);
-                
+
                 // Log successful request
                 println!(
                     "[{}] [REQUEST] IP: {} | Route: {} {} | UA: {} | Platform: {} | AppVer: {} | DeviceID: {}",
@@ -270,11 +297,13 @@ where
             }
             Ok(Err(e)) => {
                 let error_details = match e.kind() {
-                    std::io::ErrorKind::UnexpectedEof => "Unexpected EOF - client disconnected abruptly",
+                    std::io::ErrorKind::UnexpectedEof => {
+                        "Unexpected EOF - client disconnected abruptly"
+                    }
                     std::io::ErrorKind::ConnectionReset => "Connection reset by peer",
                     std::io::ErrorKind::ConnectionAborted => "Connection aborted",
                     std::io::ErrorKind::TimedOut => "Read operation timed out",
-                    _ => "Unknown IO error"
+                    _ => "Unknown IO error",
                 };
                 eprintln!(
                     "[{}] [STREAM_ERROR] IP: {} | Error attempting to read bytes out of client stream: {} (Kind: {:?}, Details: {})",
@@ -292,8 +321,12 @@ where
         }
     }
 
-    println!("[{}] [HTTP_DISCONNECT] IP: {} | Connection closed", get_timestamp(), client_addr);
-    
+    println!(
+        "[{}] [HTTP_DISCONNECT] IP: {} | Connection closed",
+        get_timestamp(),
+        client_addr
+    );
+
     match client_stream.shutdown().await {
         Ok(_) => Ok(()),
         Err(_e) => Ok(()),
@@ -487,7 +520,7 @@ pub fn extract_client_info(buffer: &[u8]) -> (String, String, String) {
     let mut platform = "Unknown".to_string();
     let mut app_version = "Unknown".to_string();
     let mut device_id = "Unknown".to_string();
-    
+
     if let Ok(buffer_str) = std::str::from_utf8(buffer) {
         for line in buffer_str.lines() {
             let line_lower = line.to_lowercase();
@@ -500,7 +533,7 @@ pub fn extract_client_info(buffer: &[u8]) -> (String, String, String) {
             }
         }
     }
-    
+
     (platform, app_version, device_id)
 }
 pub async fn listen(
@@ -558,8 +591,14 @@ pub async fn listen(
                     Ok(tls_stream) => {
                         let tls_stream = tokio_rustls::TlsStream::Server(tls_stream);
                         let client_addr = format!("{}", socket_addr);
-                        let e =
-                            handle_stream(tls_stream, liberdus, subscription_manager, config, client_addr).await;
+                        let e = handle_stream(
+                            tls_stream,
+                            liberdus,
+                            subscription_manager,
+                            config,
+                            client_addr,
+                        )
+                        .await;
                         if let Err(e) = e {
                             eprintln!("Handle Stream Error: {}", e);
                         }
@@ -574,7 +613,14 @@ pub async fn listen(
                 },
                 None => {
                     let client_addr = format!("{}", socket_addr);
-                    let e = handle_stream(raw_stream, liberdus, subscription_manager, config, client_addr).await;
+                    let e = handle_stream(
+                        raw_stream,
+                        liberdus,
+                        subscription_manager,
+                        config,
+                        client_addr,
+                    )
+                    .await;
                     if let Err(e) = e {
                         eprintln!("Handle Stream Error: {}", e);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@ pub struct Stats {
 pub mod archivers;
 pub mod collector;
 pub mod config;
-pub mod observer_gateway;
 pub mod crypto;
 pub mod http;
 pub mod liberdus;
 pub mod notifier;
+pub mod observer_gateway;
 pub mod rpc;
 pub mod shardus_monitor;
 pub mod subscription;

--- a/src/observer_gateway.rs
+++ b/src/observer_gateway.rs
@@ -39,9 +39,7 @@ where
     };
 
     let endpoint = match validate_observer_endpoint(&method, &route) {
-        ObserverEndpointValidation::AllowedNotifyBridgeout => {
-            ObserverEndpoint::NotifyBridgeout
-        }
+        ObserverEndpointValidation::AllowedNotifyBridgeout => ObserverEndpoint::NotifyBridgeout,
         ObserverEndpointValidation::AllowedPreflight => ObserverEndpoint::Preflight,
         ObserverEndpointValidation::AllowedTransactionGet(forward_route) => {
             ObserverEndpoint::TransactionGet(forward_route)
@@ -106,7 +104,12 @@ where
     // Validate request: Bridge UI sends JSON.stringify({ chainId }) — body must be {"chainId": number}
     if body.is_empty() {
         eprintln!("[notify-bridgeout] rejected: empty body");
-        respond_json(client_stream, 400, r#"{"Err":"Invalid or missing chainId"}"#).await?;
+        respond_json(
+            client_stream,
+            400,
+            r#"{"Err":"Invalid or missing chainId"}"#,
+        )
+        .await?;
         return Ok(());
     }
     let chain_id_valid = serde_json::from_slice::<serde_json::Value>(&body)
@@ -118,7 +121,12 @@ where
         .is_some();
     if !chain_id_valid {
         eprintln!("[notify-bridgeout] rejected: invalid or missing chainId in body");
-        respond_json(client_stream, 400, r#"{"Err":"Invalid or missing chainId"}"#).await?;
+        respond_json(
+            client_stream,
+            400,
+            r#"{"Err":"Invalid or missing chainId"}"#,
+        )
+        .await?;
         return Ok(());
     }
 
@@ -157,7 +165,10 @@ where
                     }
                 }
                 Err(e) => {
-                    eprintln!("[notify-bridgeout] observer request failed: {} (url={})", e, url);
+                    eprintln!(
+                        "[notify-bridgeout] observer request failed: {} (url={})",
+                        e, url
+                    );
                 }
             }
         }
@@ -524,7 +535,10 @@ fn filter_transaction_response_by_timestamp(
 
     if let Some(ok) = v.get_mut("Ok").and_then(|ok| ok.as_object_mut()) {
         let len = filtered.len() as u64;
-        ok.insert("transactions".to_string(), serde_json::Value::Array(filtered));
+        ok.insert(
+            "transactions".to_string(),
+            serde_json::Value::Array(filtered),
+        );
         ok.insert(
             "totalTranactions".to_string(),
             serde_json::Value::Number(serde_json::Number::from(len)),

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -16,7 +16,7 @@ fn get_timestamp() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    
+
     // Format as human-readable timestamp (you can adjust format as needed)
     format!("{}", now)
 }
@@ -30,6 +30,11 @@ pub enum Methods {
 pub type SocketId = String;
 pub type SocketIdents = Arc<RwLock<HashMap<SocketId, UnboundedSender<rpc::RpcResponse>>>>;
 pub type WebsocketIncoming = crate::rpc::RpcRequest<Methods>;
+
+/// Redact socket/session IDs before logging to avoid cleartext session identifiers.
+fn redact_socket_id_for_log(_socket_id: &str) -> &'static str {
+    "***"
+}
 
 fn generate_uuid() -> String {
     let mut random_bytes = [0u8; 16];
@@ -145,7 +150,9 @@ pub async fn listen(
                     Ok(tls_stream) => {
                         let tls_stream = tokio_rustls::TlsStream::Server(tls_stream);
                         let client_addr = format!("{}", socket_addr);
-                        let e = handle_stream(tls_stream, sock_map, subscription_manager, client_addr).await;
+                        let e =
+                            handle_stream(tls_stream, sock_map, subscription_manager, client_addr)
+                                .await;
                         if let Err(e) = e {
                             eprintln!("Handle Stream Error: {:?}", e);
                         }
@@ -160,7 +167,8 @@ pub async fn listen(
                 },
                 None => {
                     let client_addr = format!("{}", socket_addr);
-                    let e = handle_stream(raw_stream, sock_map, subscription_manager, client_addr).await;
+                    let e = handle_stream(raw_stream, sock_map, subscription_manager, client_addr)
+                        .await;
                     if let Err(e) = e {
                         eprintln!("Handle Stream Error: {}", e);
                     }
@@ -185,9 +193,14 @@ where
 {
     let socket_id = generate_uuid();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<rpc::RpcResponse>();
-    
-    println!("[{}] [WS_CONNECT] IP: {} | Socket ID: {}", get_timestamp(), client_addr, socket_id);
-    
+
+    println!(
+        "[{}] [WS_CONNECT] IP: {} | Socket ID: {}",
+        get_timestamp(),
+        client_addr,
+        redact_socket_id_for_log(&socket_id)
+    );
+
     let ws_stream = match tokio_tungstenite::accept_async(stream).await {
         Ok(ws_stream) => {
             {
@@ -228,7 +241,12 @@ where
             match msg {
                 Ok(msg) => match msg {
                     Message::Close(_) => {
-                        println!("[{}] [WS_DISCONNECT] IP: {} | Socket ID: {} | Client closed connection", get_timestamp(), client_addr_1, socket_id_1);
+                        println!(
+                            "[{}] [WS_DISCONNECT] IP: {} | Socket ID: {} | Client closed connection",
+                            get_timestamp(),
+                            client_addr_1,
+                            redact_socket_id_for_log(&socket_id_1)
+                        );
                         let mut guard = sock_map.write().await;
                         guard.remove(&socket_id_1);
                         subscription_manager_long_lived
@@ -241,7 +259,13 @@ where
                         let parsed: WebsocketIncoming = match serde_json::from_str(&msg) {
                             Ok(p) => p,
                             Err(e) => {
-                                eprintln!("[{}] [WS_ERROR] IP: {} | Socket ID: {} | Invalid JSON: {}", get_timestamp(), client_addr_1, socket_id_1, e);
+                                eprintln!(
+                                    "[{}] [WS_ERROR] IP: {} | Socket ID: {} | Invalid JSON: {}",
+                                    get_timestamp(),
+                                    client_addr_1,
+                                    redact_socket_id_for_log(&socket_id_1),
+                                    e
+                                );
                                 let resp = rpc::generate_error_response(
                                     None,
                                     format!("Invalid JSON: {}", e),
@@ -257,7 +281,7 @@ where
                             "[{}] [WS_MESSAGE] IP: {} | Socket ID: {} | Method: {:?} | ID: {:?}",
                             get_timestamp(),
                             client_addr_1,
-                            socket_id_1,
+                            redact_socket_id_for_log(&socket_id_1),
                             parsed.method,
                             rpc_id
                         );
@@ -269,8 +293,13 @@ where
                         )
                         .await;
                         if let Err(e) = e {
-                            eprintln!("[{}] [WS_RPC_ERROR] IP: {} | Socket ID: {} | Error handling request: {}", 
-                                     get_timestamp(), client_addr_1, socket_id_1, e);
+                            eprintln!(
+                                "[{}] [WS_RPC_ERROR] IP: {} | Socket ID: {} | Error handling request: {}",
+                                get_timestamp(),
+                                client_addr_1,
+                                redact_socket_id_for_log(&socket_id_1),
+                                e
+                            );
                             let resp = rpc::generate_error_response(
                                 Some(rpc_id),
                                 format!("Error handling request: {}", e),
@@ -280,7 +309,12 @@ where
                         }
                     }
                     Message::Pong(_) => {
-                        println!("[{}] [WS_PONG] IP: {} | Socket ID: {}", get_timestamp(), client_addr_1, socket_id_1);
+                        println!(
+                            "[{}] [WS_PONG] IP: {} | Socket ID: {}",
+                            get_timestamp(),
+                            client_addr_1,
+                            redact_socket_id_for_log(&socket_id_1)
+                        );
                         let now = SystemTime::now()
                             .duration_since(UNIX_EPOCH)
                             .unwrap()
@@ -292,9 +326,20 @@ where
                     }
                 },
                 Err(e) => {
-                    eprintln!("[{}] [WS_ERROR] IP: {} | Socket ID: {} | WebSocket error: {}", get_timestamp(), client_addr_1, socket_id_1, e);
+                    eprintln!(
+                        "[{}] [WS_ERROR] IP: {} | Socket ID: {} | WebSocket error: {}",
+                        get_timestamp(),
+                        client_addr_1,
+                        redact_socket_id_for_log(&socket_id_1),
+                        e
+                    );
                     if e.to_string().contains("Connection reset by peer") {
-                        println!("[{}] [WS_DISCONNECT] IP: {} | Socket ID: {} | Connection reset by peer", get_timestamp(), client_addr_1, socket_id_1);
+                        println!(
+                            "[{}] [WS_DISCONNECT] IP: {} | Socket ID: {} | Connection reset by peer",
+                            get_timestamp(),
+                            client_addr_1,
+                            redact_socket_id_for_log(&socket_id_1)
+                        );
                         break;
                     }
                 }
@@ -316,7 +361,12 @@ where
                 .as_secs()
                 .saturating_sub(last);
             if elapsed > heartbeat_interval_sec {
-                println!("[{}] [WS_TIMEOUT] Socket ID: {} | Closing due to heartbeat timeout ({}s elapsed)", get_timestamp(), socket_id, elapsed);
+                println!(
+                    "[{}] [WS_TIMEOUT] Socket ID: {} | Closing due to heartbeat timeout ({}s elapsed)",
+                    get_timestamp(),
+                    redact_socket_id_for_log(&socket_id),
+                    elapsed
+                );
                 subscription_manager.unsubscribe_all(&socket_id).await;
                 let mut guard = write_half_for_ping_pong.lock().await;
                 let _ = guard.close().await;
@@ -389,6 +439,14 @@ mod tests {
         assert!("89ab".contains(eighth));
     }
 
+    #[test]
+    fn redact_socket_id_for_log_masks_session_identifier() {
+        assert_eq!(
+            redact_socket_id_for_log("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+            "***"
+        );
+    }
+
     #[tokio::test]
     async fn handle_stream_processes_invalid_json_and_closes() {
         let liberdus = test_liberdus();
@@ -408,8 +466,8 @@ mod tests {
                 subscription_manager_server,
                 addr.to_string(),
             )
-                .await
-                .unwrap();
+            .await
+            .unwrap();
         });
 
         let url = format!("ws://{}", addr);
@@ -447,8 +505,8 @@ mod tests {
                 subscription_manager_server,
                 addr.to_string(),
             )
-                .await
-                .unwrap();
+            .await
+            .unwrap();
         });
 
         let url = format!("ws://{}", addr);

--- a/tests/observer_gateway_test.rs
+++ b/tests/observer_gateway_test.rs
@@ -94,9 +94,15 @@ async fn run_handle_request(request_buffer: Vec<u8>, config: Arc<config::Config>
 
 #[test]
 fn test_is_observer_route() {
-    assert!(observer_gateway::is_observer_route("/observer/notify-bridgeout"));
-    assert!(observer_gateway::is_observer_route("/observer/notify-bridgeout?x=1"));
-    assert!(observer_gateway::is_observer_route("/observer/transactions"));
+    assert!(observer_gateway::is_observer_route(
+        "/observer/notify-bridgeout"
+    ));
+    assert!(observer_gateway::is_observer_route(
+        "/observer/notify-bridgeout?x=1"
+    ));
+    assert!(observer_gateway::is_observer_route(
+        "/observer/transactions"
+    ));
     assert!(!observer_gateway::is_observer_route("/notify-bridgeout"));
     assert!(!observer_gateway::is_observer_route("/other"));
 }
@@ -107,23 +113,44 @@ async fn test_handle_request_valid_and_errors() {
     let config_no_url = Arc::new(test_config(vec![]));
 
     // Valid body → 200 accepted
-    let res = run_handle_request(post_request_with_body(r#"{"chainId":80002}"#), config_ok.clone()).await;
+    let res = run_handle_request(
+        post_request_with_body(r#"{"chainId":80002}"#),
+        config_ok.clone(),
+    )
+    .await;
     let text = String::from_utf8_lossy(&res);
-    assert!(text.starts_with("HTTP/1.1 200 OK") && text.contains(r#"{"Ok":"accepted"}"#), "{}", text);
+    assert!(
+        text.starts_with("HTTP/1.1 200 OK") && text.contains(r#"{"Ok":"accepted"}"#),
+        "{}",
+        text
+    );
     assert_cors_allow_all(&text);
 
     // Invalid bodies → 400
     for invalid_body in ["", "not json", r#"{"other":123}"#, r#"{"chainId":"80002"}"#] {
         let res = run_handle_request(post_request_with_body(invalid_body), config_ok.clone()).await;
         let text = String::from_utf8_lossy(&res);
-        assert!(text.starts_with("HTTP/1.1 400"), "body {:?} should get 400, got: {}", invalid_body, text);
+        assert!(
+            text.starts_with("HTTP/1.1 400"),
+            "body {:?} should get 400, got: {}",
+            invalid_body,
+            text
+        );
         assert_cors_allow_all(&text);
     }
 
     // No observer_urls → 503 (POST notify-bridgeout)
-    let res = run_handle_request(post_request_with_body(r#"{"chainId":80002}"#), config_no_url.clone()).await;
+    let res = run_handle_request(
+        post_request_with_body(r#"{"chainId":80002}"#),
+        config_no_url.clone(),
+    )
+    .await;
     let text = String::from_utf8_lossy(&res);
-    assert!(text.starts_with("HTTP/1.1 503") && text.contains("observer_urls not configured"), "{}", text);
+    assert!(
+        text.starts_with("HTTP/1.1 503") && text.contains("observer_urls not configured"),
+        "{}",
+        text
+    );
     assert_cors_allow_all(&text);
 
     // No observer_urls → 503 (GET /transaction)


### PR DESCRIPTION
Redact WebSocket socket IDs before logging so session identifiers are not written to stdout/stderr. Add explicit GitHub Actions permissions with contents:read by default and a separate deploy-docs job that uses contents:write only when publishing docs to gh-pages on main.